### PR TITLE
Fix sourcemaps and release common-sk v3.4.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-sk",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "files": [
     "modules/",
     "*.js",
+    "src/*.ts",
     "plugins"
   ],
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-sk",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Common Skia JS modules.",
   "homepage": "https://github.com/google/common-sk",
   "repository": "https://github.com/google/common-sk.git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": true,
     "outDir": "./modules/",
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "target": "es6",
     "types": ["chai", "mocha"]


### PR DESCRIPTION
This PR fixes the sourcemaps currently published in the common-sk NPM package. It mirros [this elements-sk PR](https://github.com/google/elements-sk/pull/59).

This PR fixes [skbug.com/13248](http://skbug.com/13248).